### PR TITLE
Python3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,6 @@ install:
   - python setup.py develop
 
 script:
-  - cd tests;  py.test -s
+  - conda activate  # to link properly to pytest
+  - cd tests
+  - pytest -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,13 @@ install:
   - cd iverilog && autoconf && ./configure && make && sudo make install && cd ..
 
   # Install conda
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH=$HOME/miniconda/bin:$PATH
   - conda update --yes conda
-  - conda install --yes pytest numpy psutil qtpy pyqt pyyaml pyzmq pytables
-  - pip install cocotb
+  - conda create --yes -n test-environment python=$TRAVIS_PYTHON_VERSION pytest numpy psutil qtpy pyqt pyyaml pyzmq pytables
+  - source activate test-environment
+  - pip install cocotb=1.0.dev3
   - pip install xvfbwrapper  # fake x server for Qt gui tests
 
   # Install basil
@@ -35,8 +36,9 @@ install:
   - python setup.py develop
 
 script:
-  - conda init bash  # https://github.com/ContinuumIO/docker-images/issues/89
-  - source ~/.bashrc  # since ==> For changes to take effect, close and re-open your current shell. <==
-  - conda activate  # to link properly to pytest
+  #- conda init bash  # https://github.com/ContinuumIO/docker-images/issues/89
+  #- source ~/.bashrc  # since ==> For changes to take effect, close and re-open your current shell. <==
+  #- conda activate  # to link properly to pytest
   - cd tests
+  - python --version
   - pytest -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - 2.7
+  - 3.7
 
 sudo: required
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - pip install xvfbwrapper  # fake x server for Qt gui tests
 
   # Install basil
-  - git clone -b v2.4.12 https://github.com/SiLab-Bonn/basil; cd basil; python setup.py develop; cd ..;
+  - git clone -b v3.0.0 https://github.com/SiLab-Bonn/basil; cd basil; python setup.py develop; cd ..;
   #- pip install 'basil_daq>=2.4.10,<3.0.0'
 
   # Install pytlu

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,6 @@ install:
   - python setup.py develop
 
 script:
-  #- conda init bash  # https://github.com/ContinuumIO/docker-images/issues/89
-  #- source ~/.bashrc  # since ==> For changes to take effect, close and re-open your current shell. <==
-  #- conda activate  # to link properly to pytest
   - cd tests
   - python --version
   - pytest -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ install:
   - pip install xvfbwrapper  # fake x server for Qt gui tests
 
   # Install basil
-  - git clone -b v3.0.0 https://github.com/SiLab-Bonn/basil; cd basil; python setup.py develop; cd ..;
-  #- pip install 'basil_daq>=2.4.10,<3.0.0'
+  #- git clone -b v3.0.0 https://github.com/SiLab-Bonn/basil; cd basil; python setup.py develop; cd ..;
+  - pip install basil-daq>=3.0.0
 
   # Install pytlu
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - conda update --yes conda
   - conda create --yes -n test-environment python=$TRAVIS_PYTHON_VERSION pytest numpy psutil qtpy pyqt pyyaml pyzmq pytables
   - source activate test-environment
-  - pip install cocotb=1.0.dev3
+  - pip install cocotb==1.0.dev3
   - pip install xvfbwrapper  # fake x server for Qt gui tests
 
   # Install basil

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ install:
   - python setup.py develop
 
 script:
+  - conda init bash  # https://github.com/ContinuumIO/docker-images/issues/89
+  - source ~/.bashrc  # since ==> For changes to take effect, close and re-open your current shell. <==
   - conda activate  # to link properly to pytest
   - cd tests
   - pytest -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - 3.7
 
 sudo: required
-dist: trusty
+dist: xenial
 
 before_install:
   - sudo add-apt-repository -y ppa:team-electronics/ppa

--- a/pytlu/ZestSC1.py
+++ b/pytlu/ZestSC1.py
@@ -172,10 +172,10 @@ class TluDevice:
         return self.read_eeprom(EEPROM['card_id'])[2]
 
     def get_serial_number(self):
-        return struct.unpack('>I', ''.join([chr(self.read_eeprom(EEPROM['serial_number'] + i)[2]) for i in range(4)]))[0]
+        return struct.unpack('>I', bytearray(''.join([chr(self.read_eeprom(EEPROM['serial_number'] + i)[2]) for i in range(4)]), 'utf-8'))[0]
 
     def get_memory_size(self):
-        return struct.unpack('>I', ''.join([chr(self.read_eeprom(EEPROM['memory_size'] + i)[2]) for i in range(4)]))[0]
+        return struct.unpack('>I', bytearray(''.join([chr(self.read_eeprom(EEPROM['memory_size'] + i)[2]) for i in range(4)]), 'utf-8'))[0]
 
     def get_firmware_version(self):
         return np.array(self.dev.ctrl_transfer(ENDPOINT['read_ctrl'],
@@ -206,7 +206,8 @@ class TluDevice:
                 logger.debug('write_register: {}'.format(ret))
 
     def read_register(self, index, length):
-        ret = array.array('B', '\x00' * length)
+        ret = array.array('B')
+        ret.frombytes(('\x00' * length).encode())
         with self._lock:
             for i in range(length):
                 ctrl_ret = self.dev.ctrl_transfer(ENDPOINT['read_ctrl'],

--- a/pytlu/__init__.py
+++ b/pytlu/__init__.py
@@ -1,4 +1,0 @@
-import sys
-
-if sys.version_info[0] < 3:
-    raise Exception("This version of PyTLU requires Python 3! Please install Python 3")

--- a/pytlu/__init__.py
+++ b/pytlu/__init__.py
@@ -1,0 +1,4 @@
+import sys
+
+if sys.version_info[0] < 3:
+    raise Exception("This version of PyTLU requires Python 3! Please install Python 3")

--- a/pytlu/fifo_readout.py
+++ b/pytlu/fifo_readout.py
@@ -2,7 +2,10 @@ import logging
 from time import sleep, time, mktime
 from threading import Thread, Event, Lock
 from collections import deque
-from queue import Queue, Empty
+try:
+    from queue import Queue, Empty  # Python3
+except ImportError:
+    from Queue import Queue, Empty  # Python2
 import sys
 import datetime
 

--- a/pytlu/fifo_readout.py
+++ b/pytlu/fifo_readout.py
@@ -2,7 +2,7 @@ import logging
 from time import sleep, time, mktime
 from threading import Thread, Event, Lock
 from collections import deque
-from Queue import Queue, Empty
+from queue import Queue, Empty
 import sys
 import datetime
 
@@ -220,7 +220,6 @@ class FifoReadout(object):
         logging.debug('Starting %s', self.watchdog_thread.name)
         while True:
             try:
-
                 if self.get_data_tlu_fifo_lost_count():
                     raise FifoError('TLU FIFO lost data error(s) detected')
             except Exception:

--- a/pytlu/online_monitor/pytlu_converter.py
+++ b/pytlu/online_monitor/pytlu_converter.py
@@ -47,7 +47,7 @@ class PyTLU(Transceiver):
         self.n_readouts = 0
         self.skipped_trigger_counter_old = 0  # variable needed to calcualte actual trigger counter
 
-    def deserialze_data(self, data):  # According to pyBAR data serilization
+    def deserialize_data(self, data):
         try:
             self.meta_data = jsonapi.loads(data)
         except ValueError:
@@ -119,8 +119,8 @@ class PyTLU(Transceiver):
                 self.update_time_indices['trigger_rate_real'] = 0
                 self.readouts = 0
 
-    def serialze_data(self, data):
-        return jsonapi.dumps(data, cls=utils.NumpyEncoder)
+    def serialize_data(self, data):
+        return utils.simple_enc(None, data)
 
     def handle_command(self, command):
         # received signal is 'ACTIVETAB tab' where tab is the name (str) of the selected tab in online monitor

--- a/pytlu/online_monitor/pytlu_converter.py
+++ b/pytlu/online_monitor/pytlu_converter.py
@@ -56,7 +56,7 @@ class PyTLU(Transceiver):
                 shape = self.meta_data.pop('shape')
                 if self.meta_data:
                     try:
-                        raw_data_array = np.frombuffer(buffer(data), dtype=dtype).reshape(shape)
+                        raw_data_array = np.frombuffer(data, dtype=dtype).reshape(shape)
                         return raw_data_array
                     except (KeyError, ValueError, TypeError):  # KeyError happens if meta data read is omitted; ValueError if np.frombuffer fails due to wrong sha
                         return None

--- a/pytlu/online_monitor/pytlu_receiver.py
+++ b/pytlu/online_monitor/pytlu_receiver.py
@@ -80,8 +80,9 @@ class PyTLU(Receiver):
                       'trigger_rate_real': self.trigger_rate_real_curve}
         self.plot_delay = 0
 
-    def deserialze_data(self, data):
-        return jsonapi.loads(data, object_hook=utils.json_numpy_obj_hook)
+    def deserialize_data(self, data):
+        datar, meta = utils.simple_dec(data)
+        return meta
 
     def handle_data_if_active(self, data):
         # look for TLU data in data stream

--- a/pytlu/tlu.py
+++ b/pytlu/tlu.py
@@ -166,7 +166,7 @@ class Tlu(Dut):
     def get_fifo_data(self):
         stream_fifo_size = self['stream_fifo'].SIZE
         if stream_fifo_size >= 16:
-            how_much_read = (stream_fifo_size / 512 + 1) * 512
+            how_much_read = (stream_fifo_size // 512 + 1) * 512
             self['stream_fifo'].SET_COUNT = how_much_read
             ret = self['intf'].read(0x0001000000000000, how_much_read)
             retint = np.frombuffer(ret, dtype=self.data_dtype)
@@ -317,7 +317,7 @@ def main():
 
     for oe in args.output_enable:
         no = oe[-1]
-        if no < 4:
+        if oe in output_ch[:4]:  # TODO: why is this needed
             chip['I2C_IP_SEL'][no] = chip.IP_SEL['RJ45'] if oe[0] == 'C' else chip.IP_SEL['LEMO']
 
     chip.write_i2c_config()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 basil_daq>=3.0.0
-online_monitor>=0.4.0<0.5
+online_monitor>=0.4.1<0.5
 numpy
 psutil
 qtpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 basil_daq>=3.0.0
-online_monitor==0.3.1
+online_monitor>=0.4.0<0.5
 numpy
 psutil
 qtpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-basil_daq>=2.4.10,<3.0.0
+basil_daq>=3.0.0
 online_monitor==0.3.1
 numpy
 psutil
 qtpy
-#PyQt5
 pyusb
 pyyaml
 pyzmq

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=install_requires,
-    setup_requires=['online_monitor>=0.4.0<0.5'],
+    setup_requires=['online_monitor>=0.4.1<0.5'],
     entry_points={
         'console_scripts': [
             'pytlu = pytlu.tlu:main',

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=install_requires,
-    python_requires=">=3.0",
-    setup_requires=['online_monitor==0.3.1'],
+    setup_requires=['online_monitor>=0.4.0<0.5'],
     entry_points={
         'console_scripts': [
             'pytlu = pytlu.tlu:main',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=install_requires,
+    python_requires=">=3.0",
     setup_requires=['online_monitor==0.3.1'],
     entry_points={
         'console_scripts': [

--- a/tests/StreamDriver.py
+++ b/tests/StreamDriver.py
@@ -21,7 +21,7 @@ from cocotb.clock import Clock
 class StreamDriver(BusDriver):
     """Abastract away interactions with the control bus.
     """
-    _signals = ["BUS_CLK", "BUS_RST", "BUS_DATA", "BUS_ADD", "BUS_RD", "BUS_WR",  "STREAM_READY", "STREAM_WRITE", "STREAM_DATA"]
+    _signals = ["BUS_CLK", "BUS_RST", "BUS_DATA", "BUS_ADD", "BUS_RD", "BUS_WR", "STREAM_READY", "STREAM_WRITE", "STREAM_DATA"]
     _optional_signals = ["BUS_BYTE_ACCESS"]
 
     def __init__(self, entity):
@@ -38,7 +38,7 @@ class StreamDriver(BusDriver):
         self._has_byte_acces = False
 
         self.BASE_ADDRESS_STREAM = 0x0001000000000000
-    
+
         # Kick off a clock generator
         cocotb.fork(Clock(self.clock, 20830).start())
 
@@ -51,7 +51,7 @@ class StreamDriver(BusDriver):
         self.bus.BUS_ADD <= self._x
         self.bus.BUS_DATA <= self._high_impedence
         self.bus.STREAM_READY <= 0
-        
+
         for _ in range(8):
             yield RisingEdge(self.clock)
 
@@ -71,27 +71,27 @@ class StreamDriver(BusDriver):
     @cocotb.coroutine
     def read(self, address, size):
         result = []
-        
+
         if address >= self.BASE_ADDRESS_STREAM:
-           result = yield self.read_stream(address, size)
+            result = yield self.read_stream(address, size)
         else:
             self.bus.BUS_DATA <= self._high_impedence
             self.bus.BUS_ADD <= self._x
             self.bus.BUS_RD <= 0
-    
+
             yield RisingEdge(self.clock)
-    
+
             byte = 0
             while(byte <= size):
                 if(byte == size):
                     self.bus.BUS_RD <= 0
                 else:
                     self.bus.BUS_RD <= 1
-    
+
                 self.bus.BUS_ADD <= address + byte
-    
+
                 yield RisingEdge(self.clock)
-    
+
                 if(byte != 0):
                     if(self._has_byte_acces and self.bus.BUS_BYTE_ACCESS.value.integer == 0):
                         result.append(self.bus.BUS_DATA.value.integer & 0x000000ff)
@@ -99,22 +99,20 @@ class StreamDriver(BusDriver):
                         result.append((self.bus.BUS_DATA.value.integer & 0x00ff0000) >> 16)
                         result.append((self.bus.BUS_DATA.value.integer & 0xff000000) >> 24)
                     else:
-                        #    result.append(self.bus.BUS_DATA.value[24:31].integer & 0xff)
+                        # result.append(self.bus.BUS_DATA.value[24:31].integer & 0xff)
                         if len(self.bus.BUS_DATA.value) == 8:
                             result.append(self.bus.BUS_DATA.value.integer & 0xff)
                         else:
-                            #value = self.bus.BUS_DATA.value[24:31].integer & 0xff
-                            
-                            #workaround for cocotb https://github.com/potentialventures/cocotb/pull/459
+                            # value = self.bus.BUS_DATA.value[24:31].integer & 0xff
+                            # workaround for cocotb https://github.com/potentialventures/cocotb/pull/459
                             value = BinaryValue(self.bus.BUS_DATA.value.binstr[24:32])
-                            
                             result.append(value.integer)
-                            
+
                 if(self._has_byte_acces and self.bus.BUS_BYTE_ACCESS.value.integer == 0):
                     byte += 4
                 else:
                     byte += 1
-    
+
             self.bus.BUS_ADD <= self._x
             self.bus.BUS_DATA <= self._high_impedence
             yield RisingEdge(self.clock)
@@ -149,31 +147,30 @@ class StreamDriver(BusDriver):
         self.bus.BUS_WR <= 0
 
         yield RisingEdge(self.clock)
-        
-        
+
     @cocotb.coroutine
     def read_stream(self, address, size):
         result = []
-        
+
         yield RisingEdge(self.clock)
         self.bus.STREAM_READY <= 1
-        
-        for _ in range(size/2):
-            
+
+        for _ in range(size // 2):
+
             yield RisingEdge(self.clock)
-            
+
             while self.bus.STREAM_WRITE.value.integer == 0:
                 yield RisingEdge(self.clock)
-                
+
             result.append(self.bus.STREAM_DATA.value.integer & 0xff)
             result.append((self.bus.STREAM_DATA.value.integer >> 8) & 0xff)
-            
+
         yield RisingEdge(self.clock)
         yield RisingEdge(self.clock)
         yield RisingEdge(self.clock)
         yield RisingEdge(self.clock)
         self.bus.STREAM_READY <= 0
         yield RisingEdge(self.clock)
-        
+
         raise ReturnValue(result)
 

--- a/tests/test_Sim.py
+++ b/tests/test_Sim.py
@@ -117,7 +117,7 @@ class TestSim(unittest.TestCase):
         self.dut['tlu_master'].EN_OUTPUT = 1
         self.dut['tlu_master'].N_BITS_TRIGGER_ID = 15
         # self.dut['tlu_master'].TIMEOUT = 3
-        
+
         how_many = 50
         self.dut['test_pulser'].DELAY = 200
         self.dut['test_pulser'].WIDTH = 10
@@ -210,7 +210,7 @@ class TestSim(unittest.TestCase):
         if tdc_en:
             exp_tdc = np.array([135] * how_many, dtype=np.uint32)
             ret_tdc = ret[~tlu_word] >> 20
-            self.assertEqual((ret_tdc / 2).tolist(), (exp_tdc / 2).tolist())
+            self.assertEqual((ret_tdc // 2).tolist(), (exp_tdc // 2).tolist())
 
         self.assertEqual(self.dut['tlu_master'].TRIGGER_ID, how_many)
         self.assertEqual(self.dut['tlu_master'].TIMEOUT_COUNTER, 0)
@@ -241,8 +241,8 @@ class TestSim(unittest.TestCase):
 
         ret_fifo = self.dut.get_fifo_data()
         self.assertEqual(ret.size, how_many)
-        self.assertEqual(range(how_many), ret_fifo['trigger_id'].tolist())
-        self.assertEqual(range(ret_fifo['time_stamp'][0], int(ret_fifo['time_stamp'][0]) + how_many * distance, distance), ret_fifo['time_stamp'].tolist())
+        self.assertEqual(list(range(how_many)), ret_fifo['trigger_id'].tolist())
+        self.assertEqual(list(range(ret_fifo['time_stamp'][0], int(ret_fifo['time_stamp'][0]) + how_many * distance, distance)), ret_fifo['time_stamp'].tolist())
 
         self.assertEqual(self.dut['tlu_master'].TRIGGER_ID, how_many)
         self.assertEqual(self.dut['tlu_master'].TIMEOUT_COUNTER, 255 if how_many > 255 else how_many)

--- a/tests/test_Sim.py
+++ b/tests/test_Sim.py
@@ -19,7 +19,7 @@ from pytlu.tlu import Tlu
 class TestSim(unittest.TestCase):
     def setUp(self):
         root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        print root_dir
+        print(root_dir)
         cocotb_compile_and_run(
             sim_bus="StreamDriver",
             sim_files=[root_dir + '/tests/tb.v'],
@@ -171,7 +171,7 @@ class TestSim(unittest.TestCase):
             ret = self.dut['FIFO_TB'].get_data()
 
             # for k,w in enumerate(ret):
-            #    print k, hex(w)
+            #    print(k, hex(w))
 
             self.assertEqual(ret.size, exp[i] * 2)
 


### PR DESCRIPTION
This PR adds Python3 support (Python2 is still supported) for pyTLU.
Concerning dependencies of pyTLU, basil 3.0.0 or higher is now required and also the latest version of the online monitor is required (0.4.1).

Both python versions 2 and 3 are tested with travis.